### PR TITLE
Add TV-VAR analysis script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # JapanMonetaryPolicyAnalysis
+
 VAR and its variants are used to analyse the impact of Japan monetary policy.
+
+## Time-Varying VAR example
+
+`tvvar_analysis.R` downloads macroeconomic data from FRED and estimates a
+Time-Varying Vector Autoregression (TV-VAR) with currency rate, GDP,
+industrial production, and a short-term interest rate.
+
+It then plots the impulse response function of a monetary policy shock
+and the forecast error variance decomposition.
+
+Run the script with:
+
+```r
+Rscript tvvar_analysis.R
+```

--- a/tvvar_analysis.R
+++ b/tvvar_analysis.R
@@ -1,0 +1,39 @@
+# Time-Varying VAR analysis of Japan monetary policy impact on currency rate
+#
+# This script downloads macroeconomic data from FRED and fits a
+# time-varying vector autoregression (TV-VAR) using the tvReg package.
+# It then plots the impulse response functions and the forecast error
+# variance decomposition.
+
+# Load required packages
+library(quantmod)   # for downloading data
+library(tvReg)      # for time-varying VAR estimation
+
+# Symbols: currency rate (JPY/USD), GDP, industrial production,
+# and short-term interest rate as a proxy for monetary policy
+symbols <- c("DEXJPUS", "JPNRGDP", "JPNIPBIS", "IR3TIB01JPM156N")
+getSymbols(symbols, src = "FRED")
+
+# Merge and convert to quarterly frequency using averages
+macro_monthly <- merge(DEXJPUS, JPNRGDP, JPNIPBIS, IR3TIB01JPM156N)
+macro_quarterly <- na.omit(apply.quarterly(macro_monthly, mean))
+colnames(macro_quarterly) <- c("currency", "gdp", "ipi", "rate")
+
+# Transform variables to logarithms where appropriate
+macro_quarterly$currency <- log(macro_quarterly$currency)
+macro_quarterly$gdp <- log(macro_quarterly$gdp)
+macro_quarterly$ipi <- log(macro_quarterly$ipi)
+
+# Estimate a time-varying VAR with two lags
+# Bandwidth is selected automatically by tvReg
+japan_tvvar <- tvVAR(macro_quarterly, p = 2, type = "const")
+
+# Impulse response of a monetary policy shock (rate) on currency
+irf_res <- tvirf(japan_tvvar, impulse = "rate", response = "currency",
+                 n.ahead = 12, ortho = TRUE, cumulative = FALSE,
+                 boot = TRUE, runs = 100)
+plot(irf_res, main = "Impulse response of policy rate shock on currency")
+
+# Forecast error variance decomposition
+fevd_res <- tvfevd(japan_tvvar, n.ahead = 12)
+plot(fevd_res, main = "Forecast error variance decomposition")


### PR DESCRIPTION
## Summary
- add `tvvar_analysis.R` demonstrating time-varying VAR for Japanese currency, GDP, industrial production, and policy rate
- document script usage in README

## Testing
- `Rscript tvvar_analysis.R` *(fails: command not found: Rscript)*

------
https://chatgpt.com/codex/tasks/task_e_68af045dd18c832fa542d35792720a29